### PR TITLE
Add support for css-parse object

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,18 @@ for (var name in names) {
  * @param {string} type A color space to stringify values to. By default - rgb.
  */
 function stringify (values, type) {
+	// Accept object from `color-parse`
+	if (!Array.isArray(values) && values.values) {
+		var color = values
+		if (values.alpha === 1 || color.alpha === undefined) {
+			return stringify(values.values, type || values.space)
+		} else {
+			var values = color.values.slice()
+			values.push(color.alpha)
+			return stringify(values, type || color.space)
+		}
+	}
+
 	if (type === 'hex') {
 		var res = values.slice(0,3).map(function (value) {
 			return (value < 16 ? '0' : '') + value.toString(16);

--- a/index.js
+++ b/index.js
@@ -25,8 +25,8 @@ function stringify (values, type) {
 	// Accept object from `color-parse`
 	if (!Array.isArray(values) && values.values) {
 		var color = values
-		if (values.alpha === 1 || color.alpha === undefined) {
-			return stringify(values.values, type || values.space)
+		if (color.alpha === 1 || color.alpha === undefined) {
+			return stringify(color.values, type || color.space)
 		} else {
 			var values = color.values.slice()
 			values.push(color.alpha)

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "chai": "^3.0.0",
+    "color-parse": "^1.3.2",
     "mocha": "^2.2.5"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ stringify([120,100,100,.4], 'hsl'); //hsla(120, 100%, 100%, .4)
 
 ### `stringify(<values>, <type>?)`
 
-`<values>` is an array.
+`<values>` is an array or an object from [`css-parse`](https://npmjs.com/color-parse)
 
 `<type>` is an optional string:
 

--- a/test.js
+++ b/test.js
@@ -1,5 +1,6 @@
 var stringify = require('./');
 var assert = require('chai').assert;
+var parse = require('color-parse')
 
 describe('color-stringify', function () {
 	it('color-string tests', function () {
@@ -39,5 +40,9 @@ describe('color-stringify', function () {
 		//percent string
 		assert.equal(stringify([10, 30, 25], 'percent'), "rgb(4%, 12%, 10%)");
 		assert.equal(stringify([10, 30, 25, 0.3], 'percent'), "rgba(4%, 12%, 10%, 0.3)");
+
+		assert.equal(stringify(parse('rgb(180, 15, 0)')), 'rgb(180, 15, 0)')
+		assert.equal(stringify(parse('rgba(120, 0, 177, 0.5)')), 'rgba(120, 0, 177, 0.5)')
+		assert.equal(stringify(parse('hsla(170, 100%, 30%, 0.8)')), 'hsla(170, 100%, 30%, 0.8)')
 	});
 });


### PR DESCRIPTION
A nice way to do transforms

```
parse(color) |> ...transforms |> stringify()
```